### PR TITLE
Add Paper's AsyncPlayerSendCommandsEvent listener

### DIFF
--- a/CommandWhitelistBukkit/pom.xml
+++ b/CommandWhitelistBukkit/pom.xml
@@ -119,5 +119,11 @@
             <version>1.0.17</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-mojangapi</artifactId>
+            <version>1.17.1-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/CommandWhitelistBukkit.java
+++ b/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/CommandWhitelistBukkit.java
@@ -1,6 +1,7 @@
 package eu.endermite.commandwhitelist.bukkit;
 
 import eu.endermite.commandwhitelist.bukkit.command.MainCommandExecutor;
+import eu.endermite.commandwhitelist.bukkit.listeners.AsyncCommandSendListener;
 import eu.endermite.commandwhitelist.bukkit.listeners.AsyncTabCompleteBlockerListener;
 import eu.endermite.commandwhitelist.bukkit.listeners.PlayerCommandPreProcessListener;
 import eu.endermite.commandwhitelist.bukkit.listeners.PlayerCommandSendListener;
@@ -43,7 +44,12 @@ public class CommandWhitelistBukkit extends JavaPlugin {
 
         if (!getConfigCache().useProtocolLib || protocollib == null || !protocollib.isEnabled()) {
             getServer().getPluginManager().registerEvents(new PlayerCommandPreProcessListener(), this);
-            getServer().getPluginManager().registerEvents(new PlayerCommandSendListener(), this);
+            try {
+                Class.forName("com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent");
+                getServer().getPluginManager().registerEvents(new AsyncCommandSendListener(), this);
+            } catch (ClassNotFoundException e){
+                getServer().getPluginManager().registerEvents(new PlayerCommandSendListener(), this);
+            }
         } else {
             PacketCommandPreProcessListener.protocol(this);
             PacketCommandSendListener.protocol(this);

--- a/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/AsyncCommandSendListener.java
+++ b/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/AsyncCommandSendListener.java
@@ -1,0 +1,23 @@
+package eu.endermite.commandwhitelist.bukkit.listeners;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+
+import eu.endermite.commandwhitelist.common.CWPermission;
+import eu.endermite.commandwhitelist.bukkit.CommandWhitelistBukkit;
+import com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent;
+
+
+import java.util.HashSet;
+
+public class AsyncCommandSendListener implements Listener {
+    @EventHandler
+    public void AsyncPlayerSendCommandsEvent(AsyncPlayerSendCommandsEvent<?> event){
+        if(!event.isAsynchronous() || event.hasFiredAsync()) return;
+        Player player = event.getPlayer();
+        if (player.hasPermission(CWPermission.BYPASS.permission())) return;
+        HashSet<String> commandList = CommandWhitelistBukkit.getCommands(player);
+        event.getCommandNode().getChildren().removeIf(commandNode -> !commandList.contains(commandNode.getName()));
+    }
+}


### PR DESCRIPTION
Added a command hint control for Paper's AsyncPlayerSendCommandsEvent https://github.com/PaperMC/Paper/blob/master/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/AsyncPlayerSendCommandsEvent.java

*I know that the event is deprecated because it is a Draft API, however, I have tested the event on my server with my own plugin for quite a while and it seems to work correctly*