### PR TITLE
Update minimessage format docs link

### DIFF
--- a/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/ConfigCache.java
+++ b/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/ConfigCache.java
@@ -42,7 +42,7 @@ public class ConfigCache {
         config.addDefault("messages.removed_from_whitelist", "<yellow>Removed command <gold>%s <yellow>from permission <gold>%s");
         config.addDefault("messages.group_doesnt_exist", "<red>Group doesn't exist or error occured");
 
-        config.addComment("messages", "Messages use MiniMessage formatting (https://docs.adventure.kyori.net/minimessage.html#format)");
+        config.addComment("messages", "Messages use MiniMessage formatting (https://docs.adventure.kyori.net/minimessage/format)");
 
         if (canDoProtocolLib)
             config.addDefault("use_protocollib", false, "Do not enable if you don't have issues with aliased commands.\nThis requires server restart to take effect.");


### PR DESCRIPTION
As per KyoriPowered/adventure-docs#45, the documentation for minimessage was split up into two pages and no longer uses a fragment in the link. While old links still continue to work, they don't directly bring the user directly to the format page as before