### PR TITLE
Add an execute only prefix to commands `~`

### DIFF
--- a/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/CommandWhitelistBukkit.java
+++ b/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/CommandWhitelistBukkit.java
@@ -119,6 +119,22 @@ public class CommandWhitelistBukkit extends JavaPlugin {
 
     /**
      * @param player Bukkit Player
+     * @return command suggestions available to the player
+     */
+    public static HashSet<String> getCommandSuggestions(org.bukkit.entity.Player player) {
+        HashSet<String> commandList = new HashSet<>();
+        HashMap<String, CWGroup> groups = configCache.getGroupList();
+        for (Map.Entry<String, CWGroup> s : groups.entrySet()) {
+            if (s.getKey().equalsIgnoreCase("default"))
+                commandList.addAll(s.getValue().getCommandSuggestions());
+            else if (player.hasPermission(s.getValue().getPermission()))
+                commandList.addAll(s.getValue().getCommandSuggestions());
+        }
+        return commandList;
+    }
+
+    /**
+     * @param player Bukkit Player
      * @return subcommands unavailable for the player
      */
     public static HashSet<String> getSuggestions(org.bukkit.entity.Player player) {

--- a/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/PlayerCommandSendListener.java
+++ b/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/PlayerCommandSendListener.java
@@ -14,7 +14,7 @@ public class PlayerCommandSendListener implements Listener {
     public void PlayerCommandSendEvent(org.bukkit.event.player.PlayerCommandSendEvent event) {
         Player player = event.getPlayer();
         if (player.hasPermission(CWPermission.BYPASS.permission())) return;
-        HashSet<String> commandList = CommandWhitelistBukkit.getCommands(player);
+        HashSet<String> commandList = CommandWhitelistBukkit.getCommandSuggestions(player);
         event.getCommands().removeIf((cmd) -> !commandList.contains(cmd));
     }
 }

--- a/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/CWGroup.java
+++ b/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/CWGroup.java
@@ -3,16 +3,19 @@ package eu.endermite.commandwhitelist.common;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class CWGroup {
 
     private final String id, permission, commandDeniedMessage;
+    private final HashSet<String> commandSuggestions = new HashSet<>();
     private final HashSet<String> commands = new HashSet<>();
     private final HashSet<String> subCommands = new HashSet<>();
 
-    public CWGroup(String id, Collection<String> commands, Collection<String> subCommands, String custom_command_denied_message) {
+    public CWGroup(String id, Collection<String> commandSuggestions, Collection<String> commands, Collection<String> subCommands, String custom_command_denied_message) {
         this.id = id;
         this.permission = "commandwhitelist.group." + id;
+        this.commandSuggestions.addAll(commandSuggestions);
         this.commands.addAll(commands);
         this.commandDeniedMessage = custom_command_denied_message;
         this.subCommands.addAll(subCommands);
@@ -26,6 +29,10 @@ public class CWGroup {
         return permission;
     }
 
+    public HashSet<String> getCommandSuggestions() {
+        return commandSuggestions;
+    }
+
     public HashSet<String> getCommands() {
         return commands;
     }
@@ -35,10 +42,16 @@ public class CWGroup {
     }
 
     public void addCommand(String command) {
-        commands.add(command);
+        if (command.startsWith("~")) {
+            commands.add(command.substring(1));
+        } else {
+            commandSuggestions.add(command);
+            commands.add(command);
+        }
     }
 
     public void removeCommand(String command) {
+        commandSuggestions.remove(command);
         commands.remove(command);
     }
 
@@ -56,7 +69,9 @@ public class CWGroup {
 
     public HashMap<String, Object> serialize() {
         HashMap<String, Object> serializedGroup = new LinkedHashMap<>();
-        List<String> commands = new ArrayList<>(this.commands);
+        List<String> commands = commandSuggestions.stream()
+                .map((suggestion) -> this.commands.contains(suggestion) ? suggestion : "~".concat(suggestion))
+                .collect(Collectors.toList());
         List<String> subCommands = new ArrayList<>(this.subCommands);
         serializedGroup.put("commands", commands);
         serializedGroup.put("subcommands", subCommands);

--- a/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/ConfigCache.java
+++ b/CommandWhitelistCommon/src/main/java/eu/endermite/commandwhitelist/common/ConfigCache.java
@@ -80,7 +80,7 @@ public class ConfigCache {
 
         String defaultCustomCommandDeniedMessage = "";
 
-        config.addDefault("groups.default", new CWGroup("default", defaultCommands, defaultSubcommands, defaultCustomCommandDeniedMessage).serialize());
+        config.addDefault("groups.default", new CWGroup("default", defaultCommands, defaultCommands, defaultSubcommands, defaultCustomCommandDeniedMessage).serialize());
 
         prefix = config.getString("messages.prefix");
         command_denied = config.getString("messages.command_denied");
@@ -124,6 +124,7 @@ public class ConfigCache {
     }
 
     public CWGroup loadCWGroup(String id, ConfigSection section) {
+        HashSet<String> suggestions = new HashSet<>();
         HashSet<String> commands = new HashSet<>();
         for (String cmd : section.getStringList(id + ".commands")) {
             if (cmd.contains(" ")) {
@@ -131,8 +132,13 @@ public class ConfigCache {
                 warn("CommandWhitelist - \"" + cmd + "\" is not a command. Loading it as \"" + cmdSplit[0] + "\".");
                 cmd = cmdSplit[0];
             }
-            if (commands.contains(cmd)) continue;
-            commands.add(cmd);
+
+            if (cmd.startsWith("~")) {
+                commands.add(cmd.substring(1));
+            } else {
+                suggestions.add(cmd);
+                commands.add(cmd);
+            }
         }
         List<String> subCommands = new ArrayList<>();
         for (String subCmd : section.getStringList(id + ".subcommands")) {
@@ -143,7 +149,7 @@ public class ConfigCache {
             subCommands.add(subCmd);
         }
         String customCommandDeniedMessage = section.getString(id + ".custom_command_denied_message");
-        return new CWGroup(id, commands, subCommands, customCommandDeniedMessage);
+        return new CWGroup(id, suggestions, commands, subCommands, customCommandDeniedMessage);
     }
 
     public void saveCWGroup(String id, CWGroup group) {

--- a/CommandWhitelistVelocity/src/main/java/eu/endermite/commandwhitelist/velocity/CommandWhitelistVelocity.java
+++ b/CommandWhitelistVelocity/src/main/java/eu/endermite/commandwhitelist/velocity/CommandWhitelistVelocity.java
@@ -73,7 +73,7 @@ public class CommandWhitelistVelocity {
     public void onUserCommandSendEvent(PlayerAvailableCommandsEvent event) {
         Player player = event.getPlayer();
         if (player.hasPermission(CWPermission.BYPASS.permission())) return;
-        HashSet<String> allowedCommands = CommandWhitelistVelocity.getCommands(player);
+        HashSet<String> allowedCommands = CommandWhitelistVelocity.getCommandSuggestions(player);
         event.getRootNode().getChildren().removeIf((commandNode) ->
                 server.getCommandManager().hasCommand(commandNode.getName())
                         && !allowedCommands.contains(commandNode.getName())
@@ -115,6 +115,23 @@ public class CommandWhitelistVelocity {
                 commandList.addAll(group.getCommands());
             else if (player.hasPermission(group.getPermission()))
                 commandList.addAll(group.getCommands());
+        }
+        return commandList;
+    }
+
+    /**
+     * @param player Velocity Player
+     * @return command suggestions available to the player
+     */
+    public static HashSet<String> getCommandSuggestions(Player player) {
+        HashMap<String, CWGroup> groups = configCache.getGroupList();
+        HashSet<String> commandList = new HashSet<>();
+        for (Map.Entry<String, CWGroup> s : groups.entrySet()) {
+            CWGroup group = s.getValue();
+            if (s.getKey().equalsIgnoreCase("default"))
+                commandList.addAll(group.getCommandSuggestions());
+            else if (player.hasPermission(group.getPermission()))
+                commandList.addAll(group.getCommandSuggestions());
         }
         return commandList;
     }

--- a/CommandWhitelistWaterfall/src/main/java/eu/endermite/commandwhitelist/waterfall/CommandWhitelistWaterfall.java
+++ b/CommandWhitelistWaterfall/src/main/java/eu/endermite/commandwhitelist/waterfall/CommandWhitelistWaterfall.java
@@ -92,6 +92,22 @@ public final class CommandWhitelistWaterfall extends Plugin {
 
     /**
      * @param player Bungee Player
+     * @return command suggestions available to the player
+     */
+    public static HashSet<String> getCommandSuggestions(ProxiedPlayer player) {
+        HashSet<String> commandList = new HashSet<>();
+        HashMap<String, CWGroup> groups = configCache.getGroupList();
+        for (Map.Entry<String, CWGroup> s : groups.entrySet()) {
+            if (s.getKey().equalsIgnoreCase("default"))
+                commandList.addAll(s.getValue().getCommandSuggestions());
+            else if (player.hasPermission(s.getValue().getPermission()))
+                commandList.addAll(s.getValue().getCommandSuggestions());
+        }
+        return commandList;
+    }
+
+    /**
+     * @param player Bungee Player
      * @return subcommands unavailable for the player
      */
     public static HashSet<String> getSuggestions(ProxiedPlayer player) {

--- a/CommandWhitelistWaterfall/src/main/java/eu/endermite/commandwhitelist/waterfall/listeners/WaterfallDefineCommandsListener.java
+++ b/CommandWhitelistWaterfall/src/main/java/eu/endermite/commandwhitelist/waterfall/listeners/WaterfallDefineCommandsListener.java
@@ -17,7 +17,7 @@ public class WaterfallDefineCommandsListener implements Listener {
             ProxiedPlayer player = (ProxiedPlayer) event.getReceiver();
             if (player.hasPermission(CWPermission.BYPASS.permission())) return;
             HashMap<String, Command> commandHashMap = new HashMap<>();
-            CommandWhitelistWaterfall.getCommands(player).forEach(cmdName ->
+            CommandWhitelistWaterfall.getCommandSuggestions(player).forEach(cmdName ->
                     CommandWhitelistWaterfall.getPlugin().getProxy().getPluginManager().getCommands()
                             .stream()
                             .filter(commandEntry -> cmdName.equalsIgnoreCase(commandEntry.getValue().getName()))


### PR DESCRIPTION
This PR is adding a way to hide commands from tab completion but still allow said command's execution, by doing this, it fixes issue #12.

# Example usage

```yml
groups:
  default:
    commands:
    - rules
    - ~cmi
    - ~cmil
```

This will only show the `/rules` command in the tab completion, but the usage of `/cmi` and `/cmil` is still allowed