### PR TITLE
Change PreprocessEvent priority to handle more deny messages

### DIFF
--- a/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/PlayerCommandPreProcessListener.java
+++ b/CommandWhitelistBukkit/src/main/java/eu/endermite/commandwhitelist/bukkit/listeners/PlayerCommandPreProcessListener.java
@@ -14,7 +14,7 @@ import org.bukkit.event.Listener;
 import java.util.HashSet;
 
 public class PlayerCommandPreProcessListener implements Listener {
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void PlayerCommandSendEvent(org.bukkit.event.player.PlayerCommandPreprocessEvent event) {
         Player player = event.getPlayer();
         if (player.hasPermission(CWPermission.BYPASS.permission())) return;


### PR DESCRIPTION
A priority of LOWEST will allow the listener to cancel the event at an earlier time, ensuring other plugins receive the event as cancelled and don't provide their own error message.